### PR TITLE
Feature/taskbaricon dispose

### DIFF
--- a/TabletFriend/TabletFriend/TrayManager.cs
+++ b/TabletFriend/TabletFriend/TrayManager.cs
@@ -56,8 +56,11 @@ namespace TabletFriend
 		}
 
 
-		private void OnQuit(object sender, RoutedEventArgs e) =>
+		private void OnQuit(object sender, RoutedEventArgs e)
+		{
+			_icon.Dispose(); 
 			Environment.Exit(0);
+		}
 
 	}
 }

--- a/TabletFriend/TabletFriend/TrayManager.cs
+++ b/TabletFriend/TabletFriend/TrayManager.cs
@@ -58,7 +58,7 @@ namespace TabletFriend
 
 		private void OnQuit(object sender, RoutedEventArgs e)
 		{
-			_icon.Dispose(); 
+			_icon.Dispose();
 			Environment.Exit(0);
 		}
 


### PR DESCRIPTION
It seems that "empty" tray entries stay open after closing the app.
Only when moving the mouse over them, they disappear.
When disposing the _icon it seems that Windows properly removes that tray entry when closing the app.